### PR TITLE
Use Map for connections storage

### DIFF
--- a/projects/ng-draw-flow/src/lib/components/connections/connections.service.spec.ts
+++ b/projects/ng-draw-flow/src/lib/components/connections/connections.service.spec.ts
@@ -1,0 +1,57 @@
+import type {DfDataConnection} from '../../ng-draw-flow.interfaces';
+import {DfConnectionPoint} from '../../ng-draw-flow.interfaces';
+import {ConnectionsService} from './connections.service';
+
+describe('ConnectionsService', () => {
+    let service: ConnectionsService;
+
+    beforeEach(() => {
+        service = new ConnectionsService();
+    });
+
+    it('adds and removes a connection', () => {
+        const conn: DfDataConnection = {
+            source: {
+                nodeId: '1',
+                connectorType: DfConnectionPoint.Output,
+                connectorId: 'a',
+            },
+            target: {
+                nodeId: '2',
+                connectorType: DfConnectionPoint.Input,
+                connectorId: 'b',
+            },
+        };
+
+        service.addConnections([conn]);
+
+        expect(service.connections$.value.size).toBe(1);
+        expect(service.usedConnectors$.value.has('a')).toBe(true);
+        expect(service.usedConnectors$.value.has('b')).toBe(true);
+
+        service.removeConnection(conn);
+
+        expect(service.connections$.value.size).toBe(0);
+        expect(service.usedConnectors$.value.size).toBe(0);
+    });
+
+    it('ignores duplicate connections', () => {
+        const conn: DfDataConnection = {
+            source: {
+                nodeId: '1',
+                connectorType: DfConnectionPoint.Output,
+                connectorId: 'a',
+            },
+            target: {
+                nodeId: '2',
+                connectorType: DfConnectionPoint.Input,
+                connectorId: 'b',
+            },
+        };
+
+        service.addConnections([conn]);
+        service.addConnections([conn]);
+
+        expect(service.connections$.value.size).toBe(1);
+    });
+});

--- a/projects/ng-draw-flow/src/lib/components/connectors/base-connector.ts
+++ b/projects/ng-draw-flow/src/lib/components/connectors/base-connector.ts
@@ -44,8 +44,8 @@ export abstract class BaseConnector {
             filter(() => !!this.data?.connectorId),
             takeUntilDestroyed(),
         )
-        .subscribe((usedConnectorIds: string[]) => {
-            this.setupDisabledState(usedConnectorIds.includes(this.data.connectorId));
+        .subscribe((usedConnectorIds: Set<string>) => {
+            this.setupDisabledState(usedConnectorIds.has(this.data.connectorId));
         });
 
     protected setupDisabledState(connected: boolean): void {

--- a/projects/ng-draw-flow/src/lib/components/scene/scene.component.ts
+++ b/projects/ng-draw-flow/src/lib/components/scene/scene.component.ts
@@ -13,7 +13,7 @@ import {
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import type {ControlValueAccessor} from '@angular/forms';
 import {NG_VALUE_ACCESSOR} from '@angular/forms';
-import {filter} from 'rxjs';
+import {filter, map} from 'rxjs';
 
 import type {
     DfDataConnection,
@@ -161,6 +161,7 @@ export class SceneComponent implements ControlValueAccessor, OnInit {
     private initializeConnectionsSubscription(): void {
         this.connectionsService.connections$
             .pipe(
+                map((connectionsMap) => Array.from(connectionsMap.values())),
                 filter(() => !!this.model),
                 takeUntilDestroyed(this.destroyRef),
             )
@@ -171,7 +172,7 @@ export class SceneComponent implements ControlValueAccessor, OnInit {
     }
 
     private emitConnectionDeletedByNodeId(nodeId: string): void {
-        this.connectionsService.connections$.value
+        Array.from(this.connectionsService.connections$.value.values())
             .filter(
                 (connection) =>
                     connection.source.nodeId === nodeId ||


### PR DESCRIPTION
## Summary
- switch ConnectionsService to Map and Set for efficient updates
- adapt BaseConnector and SceneComponent for new data structures
- add unit tests for ConnectionsService

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68417b76cc6883289d5e2afa974bf20e