### PR TITLE
Fix zoom transform coordinates

### DIFF
--- a/projects/ng-draw-flow/src/lib/components/pan-zoom/d3/d3-zoom.directive.ts
+++ b/projects/ng-draw-flow/src/lib/components/pan-zoom/d3/d3-zoom.directive.ts
@@ -44,11 +44,21 @@ export class D3ZoomDirective {
         event.preventDefault();
 
         const rect = this.element.nativeElement.getBoundingClientRect();
+        const t = this.zoom.transform();
         const offsetX = event.clientX - rect.left;
         const offsetY = event.clientY - rect.top;
 
-        const cx = offsetX >= 0 && offsetX <= rect.width ? offsetX : rect.width / 2;
-        const cy = offsetY >= 0 && offsetY <= rect.height ? offsetY : rect.height / 2;
+        const isInside =
+            offsetX >= 0 &&
+            offsetX <= rect.width &&
+            offsetY >= 0 &&
+            offsetY <= rect.height;
+
+        const cxSource = isInside ? offsetX : rect.width / 2;
+        const cySource = isInside ? offsetY : rect.height / 2;
+
+        const cx = (cxSource - t.position.x) / t.scale;
+        const cy = (cySource - t.position.y) / t.scale;
 
         const scale = 1 - event.deltaY * 0.001;
 


### PR DESCRIPTION
## Summary
- improve D3 zoom wheel handling so local coordinates are used to compute the zoom center

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a984a5e1c83288b4407ea7598ca70